### PR TITLE
Remove duplicate dependency

### DIFF
--- a/vend.gemspec
+++ b/vend.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "activesupport"
-  s.add_development_dependency "activesupport"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "webmock"


### PR DESCRIPTION
This fixes the "duplicate dependency on activesupport" validation message.
