### PR TITLE
Refactor/ruby style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,57 @@
+# class Example
+# ...
+# private
+# ...
+# end
+Style/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+# Allows foo(bar: baz)
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/DotPosition:
+  EnforcedStyle: leading
+
+Style/IndentHash:
+  EnforcedStyle: consistent
+
+Style/LineLength:
+  Max: 120
+
+Style/RedundantSelf:
+  Enabled: false
+
+# We like neatly-aligned code
+Style/SingleSpaceBeforeFirstArg:
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+# Allow single or double quotes
+Style/StringLiterals:
+  Enabled: false
+
+# Disable this until we can work out how to allow aligning of assignments
+# https://github.com/bbatsov/rubocop/blob/master/spec/rubocop/cop/style/extra_spacing_spec.rb#L23
+Style/ExtraSpacing:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rdoc/task'
 
 Dir.glob('lib/tasks/*.rake').each { |r| import r }
 
-task :default => [:spec]
+task default: [:spec]
 
 desc "Run RSpec tests"
 RSpec::Core::RakeTask.new(:spec)

--- a/example.rb
+++ b/example.rb
@@ -16,7 +16,7 @@ logger = Log4r::Logger.new 'vend'
 logger.outputters = Log4r::Outputter.stdout
 client.http_client.logger = client.logger = logger
 
-# puts client.request('products', :method => :put, :body => '{"foo":"bar"}')
+# puts client.request('products', method: :put, body: '{"foo":"bar"}')
 
 # puts "###### Products ######"
 # client.Product.all.each do |product|
@@ -29,7 +29,7 @@ client.http_client.logger = client.logger = logger
 # end
 #
 # puts "###### Creating a Customer ######"
-# response = client.request('customers', :method => :post, :body => '{"customer_code":"foo"}')
+# response = client.request('customers', method: :post, body: '{"customer_code":"foo"}')
 # puts response
 #
 # puts "###### Finding a Customer by name ######"

--- a/example.rb
+++ b/example.rb
@@ -5,7 +5,7 @@ STORE = ARGV[0]
 USERNAME = ARGV[1]
 PASSWORD = ARGV[2]
 
-unless STORE and USERNAME and PASSWORD
+unless STORE && USERNAME && PASSWORD
   $stderr.puts "Usage: example.rb store username password"
   exit 1
 end

--- a/lib/vend.rb
+++ b/lib/vend.rb
@@ -1,4 +1,4 @@
-$: << File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH << File.expand_path(File.dirname(__FILE__))
 require 'active_support/inflector'
 
 require 'vend/exception'

--- a/lib/vend/base.rb
+++ b/lib/vend/base.rb
@@ -25,6 +25,7 @@ module Vend
     def self.attribute_casts
       @attribute_casts ||= {}
     end
+
     # Returns the endpoint name for the resource, used in API urls when making
     # requests.
     def self.endpoint_name
@@ -81,7 +82,7 @@ module Vend
     #
     # And return the corresponding collection of resources
     def self.url_scope(method_name)
-      (class << self ; self ; end).instance_eval do
+      (class << self; self; end).instance_eval do
         define_method(method_name) do |client, arg|
           initialize_collection(client, collection_name).scope(method_name, arg)
         end
@@ -90,13 +91,13 @@ module Vend
     end
 
     def self.findable_by(field, options = {})
-
-      (class << self ; self ; end).instance_eval do
+      (class << self; self; end).instance_eval do
         define_method("find_by_#{field}") do |client, *args|
           search(client, options[:as] || field, *args)
         end
       end
     end
+
     # Sends a search request to the API and initializes a collection of Resources
     # from the response.
     # This method is only used internally by find_by_field methods.
@@ -129,7 +130,6 @@ module Vend
     def self.initialize_collection(client, endpoint, args = {})
       ResourceCollection.new(client, self, endpoint, args)
     end
-
 
     # Attempts to pull a singular object from Vend through the singular GET
     # endpoint.
@@ -168,7 +168,7 @@ module Vend
 
     # Overrides method_missing to query the attrs hash for the value stored
     # at the specified key before proxying it to the object
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *_args, &_block)
       if attrs.keys.include? method_name.to_s
         attribute_value_for(method_name)
       else
@@ -194,9 +194,10 @@ module Vend
       true
     end
 
-    protected
+  protected
+
     def attribute_value_for(attribute_name)
-      if self.class.attribute_casts.has_key? attribute_name
+      if self.class.attribute_casts.key? attribute_name
         case self.class.attribute_casts[attribute_name].to_s
         when "Float"
           return attrs[attribute_name.to_s].to_f

--- a/lib/vend/base.rb
+++ b/lib/vend/base.rb
@@ -102,14 +102,14 @@ module Vend
     # This method is only used internally by find_by_field methods.
     def self.search(client, field, query)
       initialize_collection(
-        client, collection_name,  :url_params => { field.to_sym => query }
+        client, collection_name,  url_params: { field.to_sym => query }
       )
     end
 
     # Builds a new instance of the described resource using the specified
     # attributes.
     def self.build(client, attrs)
-      self.new(client, :attrs => attrs)
+      self.new(client, attrs: attrs)
     end
 
     # Builds a collection of instances from a JSON response
@@ -149,7 +149,7 @@ module Vend
     # request.  I.e, to default to 500 items per page:
     #
     #   def default_collection_request_args
-    #     super.merge(:url_params => {:page_size => 500})
+    #     super.merge(url_params: {page_size: 500})
     #   end
     #
     def self.default_collection_request_args
@@ -190,7 +190,7 @@ module Vend
     def delete!
       raise(Vend::Resource::IllegalAction,
             "#{self.class.name} has no unique ID") unless attrs['id']
-      client.request(singular_name, :method => :delete)
+      client.request(singular_name, method: :delete)
       true
     end
 

--- a/lib/vend/base.rb
+++ b/lib/vend/base.rb
@@ -5,7 +5,6 @@ module Vend
   # Not all CRUD actions are available for every resource, and at current there
   # is no PUT endpoint and hence no update action
   class Base
-
     # Reference to the Vend::Client client object providing the HTTP interface to the
     # API
     attr_reader :client

--- a/lib/vend/base_factory.rb
+++ b/lib/vend/base_factory.rb
@@ -20,11 +20,11 @@ module Vend
     end
 
     ## Generates find_by_field methods which call a search on the target class
-    #def self.findable_by(field, options = {})
+    # def self.findable_by(field, options = {})
     #  url_param = options[:as] || field
     #  define_method "find_by_#{field.to_s}" do |*args|
     #    target_class.send(:search, @client, url_param, *args)
     #  end
-    #end
+    # end
   end
 end

--- a/lib/vend/base_factory.rb
+++ b/lib/vend/base_factory.rb
@@ -1,7 +1,5 @@
 module Vend
-
   class BaseFactory
-
     attr_reader :client, :target_class
 
     def initialize(client, target_class)
@@ -28,7 +26,5 @@ module Vend
     #    target_class.send(:search, @client, url_param, *args)
     #  end
     #end
-
   end
-
 end

--- a/lib/vend/client.rb
+++ b/lib/vend/client.rb
@@ -1,7 +1,6 @@
 require 'forwardable'
 
 module Vend #:nodoc:
-
   # Main access point which allows resources within the Vend gem to
   # make HTTP requests to the Vend API.
   #
@@ -10,7 +9,6 @@ module Vend #:nodoc:
   #   * a valid username and password
   #
   class Client
-
     DEFAULT_OPTIONS = {}
 
     extend Forwardable
@@ -76,7 +74,5 @@ module Vend #:nodoc:
         :base_url => base_url, :username => username, :password => password
       )
     end
-
   end
-
 end

--- a/lib/vend/client.rb
+++ b/lib/vend/client.rb
@@ -71,7 +71,7 @@ module Vend #:nodoc:
 
     def http_client_options
       options.merge(
-        :base_url => base_url, :username => username, :password => password
+        base_url: base_url, username: username, password: password
       )
     end
   end

--- a/lib/vend/http_client.rb
+++ b/lib/vend/http_client.rb
@@ -43,25 +43,25 @@ module Vend
     #
     # An optional hash of arguments may be specified. Possible options include:
     #   :method - The HTTP method
-    #     E.g. request('foo', :method => :post) will perform a POST request for
+    #     E.g. request('foo', method: :post) will perform a POST request for
     #          http://storeurl.vendhq.com/api/foo
     #
     #   :url_params - The URL parameters for GET requests.
-    #     E.g. request('foo', :url_params => {:bar => "baz"}) will request
+    #     E.g. request('foo', url_params: {bar: "baz"}) will request
     #          http://storeurl.vendhq.com/api/foo?bar=baz
     #
     #   :id - The ID required for performing actions on specific resources
     #         (e.g. delete).
-    #     E.g. request('foos', :method => :delete, :id => 1) will request
+    #     E.g. request('foos', method: :delete, id: 1) will request
     #          DELETE http://storeurl.vendhq.com/api/foos/1
     #
     #   :body - The request body
     #     E.g. For submitting a POST to http://storeurl.vendhq.com/api/foo
     #          with the JSON data {"baz":"baloo"} we would call
-    #          request('foo', :method => :post, :body => '{\"baz\":\"baloo\"}'
+    #          request('foo', method: :post, body: '{\"baz\":\"baloo\"}'
     #
     def request(path, options = {})
-      options = {:method => :get, :redirect_count => 0}.merge options
+      options = {method: :get, redirect_count: 0}.merge options
       raise RedirectionLimitExceeded if options[:redirect_count] > 10
       url = if path.kind_of?(URI)
               path
@@ -105,8 +105,8 @@ module Vend
     # Internal method to parse URL parameters.
     # Returns an empty string from a nil argument
     #
-    # E.g. url_params_for({:field => "value"}) will return ?field=value
-    # url_params_for({:field => ["value1","value2"]}) will return ?field[]=value1&field[]=value2
+    # E.g. url_params_for({field: "value"}) will return ?field=value
+    # url_params_for({field: ["value1","value2"]}) will return ?field[]=value1&field[]=value2
     protected
     def url_params_for(options)
       ary = Array.new

--- a/lib/vend/http_client.rb
+++ b/lib/vend/http_client.rb
@@ -3,7 +3,6 @@ require 'json'
 require 'cgi'
 module Vend
   class HttpClient
-
     UNAUTHORIZED_MESSAGE = "Client not authorized. Check your store credentials are correct and try again."
     # Read timeout in seconds
     READ_TIMEOUT = 240

--- a/lib/vend/null_logger.rb
+++ b/lib/vend/null_logger.rb
@@ -1,9 +1,13 @@
 module Vend
   class NullLogger
-    def debug(*args) ; end
-    def info(*args) ; end
-    def warn(*args) ; end
-    def error(*args) ; end
-    def fatal(*args) ; end
+    def debug(*_args); end
+
+    def info(*_args); end
+
+    def warn(*_args); end
+
+    def error(*_args); end
+
+    def fatal(*_args); end
   end
 end

--- a/lib/vend/oauth2/auth_code.rb
+++ b/lib/vend/oauth2/auth_code.rb
@@ -2,9 +2,7 @@ require 'oauth2'
 
 module Vend
   module Oauth2
-
     class AuthCode
-
       DEFAULT_OPTIONS = {}
       AUTHORIZE_URL = '/connect'
       TOKEN_URL = '/api/1.0/token'
@@ -33,16 +31,15 @@ module Vend
         access_token.refresh!
       end
 
-      protected
+    protected
+
       def get_oauth2_client(domain_prefix = 'secure')
         OAuth2::Client.new(client_id, secret, {
-            site: "https://#{domain_prefix}.vendhq.com",
-            authorize_url: AUTHORIZE_URL,
-            token_url: TOKEN_URL
+          site: "https://#{domain_prefix}.vendhq.com",
+          authorize_url: AUTHORIZE_URL,
+          token_url: TOKEN_URL
         })
       end
-
     end
-
   end
 end

--- a/lib/vend/oauth2/auth_code.rb
+++ b/lib/vend/oauth2/auth_code.rb
@@ -20,12 +20,12 @@ module Vend
       end
 
       def authorize_url
-        get_oauth2_client.auth_code.authorize_url(:redirect_uri => redirect_uri)
+        get_oauth2_client.auth_code.authorize_url(redirect_uri: redirect_uri)
       end
 
       def token_from_code(code)
         client = get_oauth2_client(store)
-        client.auth_code.get_token(code, :redirect_uri => redirect_uri)
+        client.auth_code.get_token(code, redirect_uri: redirect_uri)
       end
 
       def refresh_token(auth_token, refresh_token)

--- a/lib/vend/oauth2/client.rb
+++ b/lib/vend/oauth2/client.rb
@@ -1,8 +1,6 @@
 module Vend
   module Oauth2
-
     class Client < Vend::Client
-
       DEFAULT_OPTIONS = {}
 
       include Logable
@@ -21,11 +19,9 @@ module Vend
 
       def http_client_options
         options.merge(
-            auth_token: @auth_token, base_url: base_url
+          auth_token: @auth_token, base_url: base_url
         )
       end
-
     end
-
   end
 end

--- a/lib/vend/oauth2/client.rb
+++ b/lib/vend/oauth2/client.rb
@@ -21,7 +21,7 @@ module Vend
 
       def http_client_options
         options.merge(
-            :auth_token => @auth_token, :base_url => base_url
+            auth_token: @auth_token, base_url: base_url
         )
       end
 

--- a/lib/vend/pagination_info.rb
+++ b/lib/vend/pagination_info.rb
@@ -22,7 +22,8 @@ module Vend
       pages == page
     end
 
-    protected
+  protected
+
     def pagination
       @pagination ||= (response['pagination'] || {"pages" => 1, "page" => 1})
     end

--- a/lib/vend/resource/customer.rb
+++ b/lib/vend/resource/customer.rb
@@ -1,11 +1,9 @@
 module Vend
   module Resource
-
     class Customer < Vend::Base
       url_scope :since
       findable_by :email
-      findable_by :name, :as => :q
+      findable_by :name, as: :q
     end
-
   end
 end

--- a/lib/vend/resource/outlet.rb
+++ b/lib/vend/resource/outlet.rb
@@ -1,7 +1,5 @@
 module Vend
   module Resource
-
     class Outlet < Vend::Base; end
-
   end
 end

--- a/lib/vend/resource/payment_type.rb
+++ b/lib/vend/resource/payment_type.rb
@@ -1,7 +1,5 @@
 module Vend
   module Resource
-
     class PaymentType < Vend::Base; end
-
   end
 end

--- a/lib/vend/resource/product.rb
+++ b/lib/vend/resource/product.rb
@@ -1,12 +1,10 @@
 module Vend
   module Resource
-
     class Product < Vend::Base
       url_scope :since
       url_scope :active
 
       cast_attribute :supply_price, Float
     end
-
   end
 end

--- a/lib/vend/resource/register.rb
+++ b/lib/vend/resource/register.rb
@@ -1,7 +1,5 @@
 module Vend
   module Resource
-
     class Register < Vend::Base; end
-
   end
 end

--- a/lib/vend/resource/register_sale.rb
+++ b/lib/vend/resource/register_sale.rb
@@ -4,7 +4,7 @@ module Vend
       url_scope :since
       url_scope :outlet_id
       url_scope :tag
-      findable_by :state, :as => :status
+      findable_by :state, as: :status
 
       def register_sale_products
         attrs["register_sale_products"].collect do |sale_product_attrs|
@@ -13,7 +13,7 @@ module Vend
       end
 
       def self.default_collection_request_args
-        super.merge(:url_params => {:page_size => 200})
+        super.merge(url_params: {page_size: 200})
       end
     end
   end

--- a/lib/vend/resource/register_sale.rb
+++ b/lib/vend/resource/register_sale.rb
@@ -1,7 +1,5 @@
-
 module Vend
   module Resource
-
     class RegisterSale < Vend::Base
       url_scope :since
       url_scope :outlet_id
@@ -18,6 +16,5 @@ module Vend
         super.merge(:url_params => {:page_size => 200})
       end
     end
-
   end
 end

--- a/lib/vend/resource/register_sale_product.rb
+++ b/lib/vend/resource/register_sale_product.rb
@@ -9,7 +9,7 @@ module Vend
         @attrs = attrs
       end
 
-      def method_missing(method_name, *args, &block)
+      def method_missing(method_name, *_args, &_block)
         if attrs.keys.include? method_name.to_s
           attrs[method_name.to_s]
         else

--- a/lib/vend/resource/tax.rb
+++ b/lib/vend/resource/tax.rb
@@ -1,7 +1,5 @@
 module Vend
   module Resource
-
     class Tax < Vend::Base; end
-
   end
 end

--- a/lib/vend/resource/user.rb
+++ b/lib/vend/resource/user.rb
@@ -1,7 +1,5 @@
 module Vend
   module Resource
-
     class User < Vend::Base; end
-
   end
 end

--- a/lib/vend/resource_collection.rb
+++ b/lib/vend/resource_collection.rb
@@ -4,9 +4,9 @@ module Vend
   # resources.  This class will automatically fetch paginated results if the
   # target_class supports it.
   class ResourceCollection
-    class PageOutOfBoundsError  < StandardError ; end
-    class AlreadyScopedError    < StandardError ; end
-    class ScopeNotFoundError    < StandardError ; end
+    class PageOutOfBoundsError < StandardError; end
+    class AlreadyScopedError < StandardError; end
+    class ScopeNotFoundError < StandardError; end
 
     include Enumerable
     extend Forwardable
@@ -38,9 +38,7 @@ module Vend
     end
 
     def pagination
-      if response.instance_of? Hash
-        PaginationInfo.new(response)
-      end
+      PaginationInfo.new(response) if response.instance_of? Hash
     end
 
     def last_page?
@@ -65,7 +63,7 @@ module Vend
     end
 
     def has_scope?(name)
-      scopes.any? {|s| s.name == name }
+      scopes.any? { |s| s.name == name }
     end
 
     def method_missing(method_name, *args, &block)
@@ -89,20 +87,17 @@ module Vend
     end
 
     def get_scope(name)
-
       result = scopes.find { |scope| scope.name == name }
       if result.nil?
         raise ScopeNotFoundError.new(
           "Scope: #{name} was not found in #{scopes}."
         )
       end
-      return result
+      result
     end
 
     def get_or_create_page_scope
-      unless has_scope? :page
-        scope(:page, page)
-      end
+      scope(:page, page) unless has_scope? :page
       get_scope :page
     end
 
@@ -115,10 +110,12 @@ module Vend
       endpoint + scopes.join
     end
 
-    protected
+  protected
+
     attr_accessor :response
 
-    protected
+  protected
+
     def get_next_page
       if last_page?
         raise PageOutOfBoundsError.new(

--- a/lib/vend/resource_collection.rb
+++ b/lib/vend/resource_collection.rb
@@ -4,7 +4,6 @@ module Vend
   # resources.  This class will automatically fetch paginated results if the
   # target_class supports it.
   class ResourceCollection
-
     class PageOutOfBoundsError  < StandardError ; end
     class AlreadyScopedError    < StandardError ; end
     class ScopeNotFoundError    < StandardError ; end

--- a/lib/vend/scope.rb
+++ b/lib/vend/scope.rb
@@ -1,6 +1,5 @@
 module Vend
   class Scope
-
     attr_reader :name
     attr_accessor :value
 

--- a/lib/vend/scope.rb
+++ b/lib/vend/scope.rb
@@ -16,7 +16,7 @@ module Vend
       else
         result = value.to_s
       end
-      CGI::escape(result)
+      CGI.escape(result)
     end
 
     def to_s

--- a/spec/integration/customer_spec.rb
+++ b/spec/integration/customer_spec.rb
@@ -24,8 +24,8 @@ describe Vend::Resource::Customer do
   end
 
   it "returns a collection of customers from a search" do
-    stub_request(:get, "https://bar:baz@foo.vendhq.com/api/customers?email=foo@example.com").
-      to_return(status: 200, body: get_mock_response('customers.find_by_email.json'))
+    stub_request(:get, "https://bar:baz@foo.vendhq.com/api/customers?email=foo@example.com")
+      .to_return(status: 200, body: get_mock_response('customers.find_by_email.json'))
 
     collection = client.Customer.find_by_email('foo@example.com')
     expect(collection.first).to be_a Vend::Resource::Customer

--- a/spec/integration/customer_spec.rb
+++ b/spec/integration/customer_spec.rb
@@ -25,7 +25,7 @@ describe Vend::Resource::Customer do
 
   it "returns a collection of customers from a search" do
     stub_request(:get, "https://bar:baz@foo.vendhq.com/api/customers?email=foo@example.com").
-      to_return(status: 200, :body => get_mock_response('customers.find_by_email.json'))
+      to_return(status: 200, body: get_mock_response('customers.find_by_email.json'))
 
     collection = client.Customer.find_by_email('foo@example.com')
     expect(collection.first).to be_a Vend::Resource::Customer

--- a/spec/integration/outlet_spec.rb
+++ b/spec/integration/outlet_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Vend::Resource::Outlet do
-
   let(:expected_attributes) do
     {
       'id'              => '6cb5c88c-3d5f-11e0-8697-4040f540b50a',
-      'name'   => 'Main Outlet',
+      'name'   => 'Main Outlet'
     }
   end
 

--- a/spec/integration/payment_types_spec.rb
+++ b/spec/integration/payment_types_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::PaymentType do
-
   let(:expected_attributes) do
     {
       'id'              => '6cde3ba0-3d5f-11e0-8697-4040f540b50a',

--- a/spec/integration/product_spec.rb
+++ b/spec/integration/product_spec.rb
@@ -29,12 +29,12 @@ describe Vend::Resource::Product do
       stub_request( :get,
         "https://#{username}:#{password}@#{store}.vendhq.com/api/products"
       ).to_return(
-        :status => 200, :body => get_mock_response('products/page/1.json')
+        status: 200, body: get_mock_response('products/page/1.json')
       )
       stub_request( :get,
         "https://#{username}:#{password}@#{store}.vendhq.com/api/products/page/2"
       ).to_return(
-        :status => 200, :body => get_mock_response('products/page/2.json')
+        status: 200, body: get_mock_response('products/page/2.json')
       )
     end
 
@@ -62,7 +62,7 @@ describe Vend::Resource::Product do
       stub_request( :get,
         "https://#{username}:#{password}@#{store}.vendhq.com/api/products/active/1/since/2012-07-05+11:12:13"
       ).to_return(
-        :status => 200, :body => get_mock_response('products.active.since.json')
+        status: 200, body: get_mock_response('products.active.since.json')
       )
     end
 

--- a/spec/integration/product_spec.rb
+++ b/spec/integration/product_spec.rb
@@ -16,26 +16,25 @@ describe Vend::Resource::Product do
   it_behaves_like "a resource with a DELETE endpoint"
 
   describe "pagination" do
-
-    let(:username)  {"foo"}
-    let(:password)  {"bar"}
-    let(:store)     {"baz"}
+    let(:username)  { "foo" }
+    let(:password)  { "bar" }
+    let(:store)     { "baz" }
 
     let(:client) do
       Vend::Client.new(store, username, password)
     end
 
     before do
-      stub_request( :get,
-        "https://#{username}:#{password}@#{store}.vendhq.com/api/products"
-      ).to_return(
-        status: 200, body: get_mock_response('products/page/1.json')
-      )
-      stub_request( :get,
-        "https://#{username}:#{password}@#{store}.vendhq.com/api/products/page/2"
-      ).to_return(
-        status: 200, body: get_mock_response('products/page/2.json')
-      )
+      stub_request(:get,
+                   "https://#{username}:#{password}@#{store}.vendhq.com/api/products"
+                  ).to_return(
+                    status: 200, body: get_mock_response('products/page/1.json')
+                  )
+      stub_request(:get,
+                   "https://#{username}:#{password}@#{store}.vendhq.com/api/products/page/2"
+                  ).to_return(
+                    status: 200, body: get_mock_response('products/page/2.json')
+                  )
     end
 
     it "returns paginated results" do
@@ -48,22 +47,22 @@ describe Vend::Resource::Product do
   end
 
   describe "chaining" do
-    let(:username)  {"foo"}
-    let(:password)  {"bar"}
-    let(:store)     {"baz"}
+    let(:username)  { "foo" }
+    let(:password)  { "bar" }
+    let(:store)     { "baz" }
 
-    let(:timestamp) { Time.new(2012,7,5,11,12,13) }
+    let(:timestamp) { Time.new(2012, 7, 5, 11, 12, 13) }
 
     let(:client) do
       Vend::Client.new(store, username, password)
     end
 
     before do
-      stub_request( :get,
-        "https://#{username}:#{password}@#{store}.vendhq.com/api/products/active/1/since/2012-07-05+11:12:13"
-      ).to_return(
-        status: 200, body: get_mock_response('products.active.since.json')
-      )
+      stub_request(:get,
+                   "https://#{username}:#{password}@#{store}.vendhq.com/api/products/active/1/since/2012-07-05+11:12:13"
+                  ).to_return(
+                    status: 200, body: get_mock_response('products.active.since.json')
+                  )
     end
 
     it "allows scope chaining" do

--- a/spec/integration/register_sale_spec.rb
+++ b/spec/integration/register_sale_spec.rb
@@ -27,7 +27,7 @@ describe Vend::Resource::RegisterSale do
     expect(client.RegisterSale).to respond_to(:find_by_state)
 
     stub_request(:get, "https://bar:baz@foo.vendhq.com/api/register_sales?status[]=OPEN&status[]=CLOSED").
-      to_return(:status => 200, :body => get_mock_response('register_sales.find_by_state.json'))
+      to_return(status: 200, body: get_mock_response('register_sales.find_by_state.json'))
 
     collection = client.RegisterSale.find_by_state([:OPEN, :CLOSED])
     expect(collection.first).to be_a Vend::Resource::RegisterSale

--- a/spec/integration/register_sale_spec.rb
+++ b/spec/integration/register_sale_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::RegisterSale do
-
   let(:expected_attributes) do
     {
       'id'              => '98ce3dbf-e862-c811-fa93-10f6db3a8f66',
@@ -26,8 +25,8 @@ describe Vend::Resource::RegisterSale do
   it "register_sales are findable by state" do
     expect(client.RegisterSale).to respond_to(:find_by_state)
 
-    stub_request(:get, "https://bar:baz@foo.vendhq.com/api/register_sales?status[]=OPEN&status[]=CLOSED").
-      to_return(status: 200, body: get_mock_response('register_sales.find_by_state.json'))
+    stub_request(:get, "https://bar:baz@foo.vendhq.com/api/register_sales?status[]=OPEN&status[]=CLOSED")
+      .to_return(status: 200, body: get_mock_response('register_sales.find_by_state.json'))
 
     collection = client.RegisterSale.find_by_state([:OPEN, :CLOSED])
     expect(collection.first).to be_a Vend::Resource::RegisterSale

--- a/spec/integration/register_spec.rb
+++ b/spec/integration/register_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::Register do
-
   let(:expected_attributes) do
     {
       'id'              => '6cbe2342-3d5f-11e0-8697-4040f540b50a',

--- a/spec/integration/tax_spec.rb
+++ b/spec/integration/tax_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::Tax do
-
   let(:expected_attributes) do
     {
       'id'        => '53b3501c-887c-102d-8a4b-a9cf13f17faa',

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::User do
-
   let(:expected_attributes) do
     {
       'id'        => '6ce4286c-3d5f-11e0-8697-4040f540b50a',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'webmock/rspec'
 require 'pry'
-Dir["./spec/support/**/*.rb"].each {|f| require f}
+Dir["./spec/support/**/*.rb"].each { |f| require f }
 
 require 'cgi'
 require 'vend'

--- a/spec/support/matchers/have_attributes.rb
+++ b/spec/support/matchers/have_attributes.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :have_attributes do |expected|
-  match do |attributes|
-    expected.each do |key,value|
+  match do |_attributes|
+    expected.each do |key, value|
       expect(actual.send(key)).to eq value
     end
   end

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -55,8 +55,8 @@ shared_examples "a resource with a singular GET endpoint" do
   end
 
   it "gets the resource" do
-    stub_request(:get, "https://#{username}:#{password}@#{store}.vendhq.com/api/#{class_basename.to_s.underscore.pluralize}/#{id}").
-    to_return(status: 200, body: get_mock_from_path(:get, id: id))
+    stub_request(:get, "https://#{username}:#{password}@#{store}.vendhq.com/api/#{class_basename.to_s.underscore.pluralize}/#{id}")
+    .to_return(status: 200, body: get_mock_from_path(:get, id: id))
 
     objekt = build_receiver.find(id)
     expect(objekt).to have_attributes(expected_attributes)
@@ -73,9 +73,8 @@ shared_examples "a resource with a DELETE endpoint" do
   end
 
   it "deletes the resource" do
-
-    stub_request(:delete, "https://#{username}:#{password}@#{store}.vendhq.com/api/#{class_basename.to_s.underscore.pluralize}/#{expected_attributes['id']}").
-    to_return(status: 200, body: {}.to_json)
+    stub_request(:delete, "https://#{username}:#{password}@#{store}.vendhq.com/api/#{class_basename.to_s.underscore.pluralize}/#{expected_attributes['id']}")
+    .to_return(status: 200, body: {}.to_json)
 
     objekt = build_receiver.build(expected_attributes)
     expect(objekt.delete).to be_truthy

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -56,7 +56,7 @@ shared_examples "a resource with a singular GET endpoint" do
 
   it "gets the resource" do
     stub_request(:get, "https://#{username}:#{password}@#{store}.vendhq.com/api/#{class_basename.to_s.underscore.pluralize}/#{id}").
-    to_return(:status => 200, :body => get_mock_from_path(:get, :id => id))
+    to_return(status: 200, body: get_mock_from_path(:get, id: id))
 
     objekt = build_receiver.find(id)
     expect(objekt).to have_attributes(expected_attributes)

--- a/spec/support/shared_examples/logger.rb
+++ b/spec/support/shared_examples/logger.rb
@@ -22,7 +22,6 @@ end
 
 shared_examples_for "it has a logger" do
   describe "#logger" do
-
     let(:logger)  { double("logger") }
 
     it "defaults to a null logger" do

--- a/spec/vend/base_factory_spec.rb
+++ b/spec/vend/base_factory_spec.rb
@@ -7,7 +7,7 @@ describe Vend::BaseFactory do
   class Vend::Resource::Foo < Vend::Base #:nodoc:
   end
 
-  let(:client) { double() }
+  let(:client) { double }
   subject { Vend::Resource::FooFactory.new(client, Vend::Resource::Foo) }
 
   it "initializes correctly" do

--- a/spec/vend/base_spec.rb
+++ b/spec/vend/base_spec.rb
@@ -7,14 +7,14 @@ describe Vend::Base do
 
   let(:client) { double(:client) }
   let(:attribute_hash) { { key: 'value', 'id' => 1} }
-  let(:mock_response) {
+  let(:mock_response) do
     {
-      'foos'=>[
-        {'id'=>'1','bar'=>'baz'},
-        {'id'=>'2','flar'=>'flum'}
+      'foos' => [
+        {'id' => '1', 'bar' => 'baz'},
+        {'id' => '2', 'flar' => 'flum'}
       ]
     }
-  }
+  end
 
   subject { Vend::Resource::Foo.new(client, attrs: attribute_hash) }
 
@@ -42,7 +42,6 @@ describe Vend::Base do
       expect(resource).to be_a Vend::Resource::Foo
       expect(resource.bar).to eq 'baz'
     end
-
   end
 
   describe '.initialize_collection' do
@@ -205,7 +204,7 @@ describe Vend::Base do
     context 'when id is present' do
       subject { Vend::Resource::Foo.new(client, attrs: {'id' => 1}) }
 
-      let(:singular_name) { double('singular_name')}
+      let(:singular_name) { double('singular_name') }
 
       before do
         subject.stub(singular_name: singular_name)
@@ -222,9 +221,9 @@ describe Vend::Base do
 
       it 'raises Vend::Resource::IllegalAction' do
         expect(client).to_not receive(:request)
-        expect {
+        expect do
           subject.delete!
-        }.to raise_error(Vend::Resource::IllegalAction, 'Vend::Resource::Foo has no unique ID')
+        end.to raise_error(Vend::Resource::IllegalAction, 'Vend::Resource::Foo has no unique ID')
       end
     end
   end
@@ -260,7 +259,7 @@ describe Vend::Base do
   end
 
   describe '.accepts_scope?' do
-    let(:scope_name) {:scope_name}
+    let(:scope_name) { :scope_name }
     subject { Vend::Resource::Foo }
 
     context 'when scope is accepted' do

--- a/spec/vend/base_spec.rb
+++ b/spec/vend/base_spec.rb
@@ -16,7 +16,7 @@ describe Vend::Base do
     }
   }
 
-  subject { Vend::Resource::Foo.new(client, :attrs => attribute_hash) }
+  subject { Vend::Resource::Foo.new(client, attrs: attribute_hash) }
 
   it 'creates an instance of Foo' do
     expect(subject).to be_instance_of(Vend::Resource::Foo)
@@ -114,7 +114,7 @@ describe Vend::Base do
     let(:resource_collection) { double('resource_collection') }
 
     before do
-      subject.stub(:collection_name => collection_name)
+      subject.stub(collection_name: collection_name)
     end
 
     it 'calls initialize_collection with the collection_name' do
@@ -133,7 +133,7 @@ describe Vend::Base do
     let(:bar)                 { double('bar') }
 
     before do
-      subject.stub(:collection_name => collection_name)
+      subject.stub(collection_name: collection_name)
     end
 
     it 'calls initialize_collection with collection_name and :bar arg' do
@@ -156,12 +156,12 @@ describe Vend::Base do
     let(:query)               { 'query' }
 
     before do
-      subject.stub(:collection_name => collection_name)
+      subject.stub(collection_name: collection_name)
     end
 
     it 'calls initialize_collection with collection_name and :outlet_id arg' do
       expect(subject).to receive(:initialize_collection).with(
-        client, collection_name, :url_params => { field.to_sym => query }
+        client, collection_name, url_params: { field.to_sym => query }
       ) { resource_collection }
       expect(subject.search(client, field, query)).to eq resource_collection
     end
@@ -188,7 +188,7 @@ describe Vend::Base do
 
   describe 'dynamic instance methods' do
     let(:attrs) { { 'one' => 'foo', 'two' => 'bar', 'object_id' => 'fail' } }
-    subject { Vend::Resource::Foo.new(client, :attrs => attrs) }
+    subject { Vend::Resource::Foo.new(client, attrs: attrs) }
 
     it 'responds to top level attributes' do
       expect(subject).to respond_to(:one)
@@ -203,12 +203,12 @@ describe Vend::Base do
 
   describe 'delete!' do
     context 'when id is present' do
-      subject { Vend::Resource::Foo.new(client, :attrs => {'id' => 1}) }
+      subject { Vend::Resource::Foo.new(client, attrs: {'id' => 1}) }
 
       let(:singular_name) { double('singular_name')}
 
       before do
-        subject.stub(:singular_name => singular_name)
+        subject.stub(singular_name: singular_name)
       end
 
       it 'deletes the object' do
@@ -218,7 +218,7 @@ describe Vend::Base do
     end
 
     context 'when id is absent' do
-      subject { Vend::Resource::Foo.new(client, :attrs => {:foo => 'bar'}) }
+      subject { Vend::Resource::Foo.new(client, attrs: {foo: 'bar'}) }
 
       it 'raises Vend::Resource::IllegalAction' do
         expect(client).to_not receive(:request)
@@ -231,7 +231,7 @@ describe Vend::Base do
 
   describe 'delete' do
     it 'returns false when no id is present' do
-      subject = Vend::Resource::Foo.new(client, :attrs => {:foo => 'bar'})
+      subject = Vend::Resource::Foo.new(client, attrs: {foo: 'bar'})
       expect(client).to_not receive(:request)
       expect(subject.delete).to be_falsey
     end

--- a/spec/vend/client_spec.rb
+++ b/spec/vend/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Vend::Client do
-  subject { Vend::Client.new('store','user','password') }
+  subject { Vend::Client.new('store', 'user', 'password') }
   it_behaves_like "it has a logger"
 
   specify :store do
@@ -26,7 +26,7 @@ describe Vend::Client do
 
   it "sets options" do
     options = { key: :value }
-    client = Vend::Client.new('store','user','password', options)
+    client = Vend::Client.new('store', 'user', 'password', options)
     options.each do |key, value|
       expect(client.options[key]).to eq value
     end
@@ -55,7 +55,6 @@ describe Vend::Client do
   end
 
   describe "#http_client_options" do
-
     let(:options)   { {foo: 'bar'} }
     let(:base_url)  { "http://foo/" }
     let(:username)  { "username" }
@@ -80,7 +79,6 @@ describe Vend::Client do
   end
 
   describe "#request" do
-
     let(:response)    { double("response") }
     let(:http_client) { double("http_client") }
 

--- a/spec/vend/client_spec.rb
+++ b/spec/vend/client_spec.rb
@@ -25,7 +25,7 @@ describe Vend::Client do
   end
 
   it "sets options" do
-    options = { :key => :value }
+    options = { key: :value }
     client = Vend::Client.new('store','user','password', options)
     options.each do |key, value|
       expect(client.options[key]).to eq value
@@ -44,7 +44,7 @@ describe Vend::Client do
     let(:http_client_options) { double("http_client_options") }
 
     before do
-      subject.stub(:http_client_options => http_client_options)
+      subject.stub(http_client_options: http_client_options)
       expect(Vend::HttpClient).to receive(:new).with(http_client_options) { http_client }
     end
 
@@ -56,17 +56,17 @@ describe Vend::Client do
 
   describe "#http_client_options" do
 
-    let(:options)   { {:foo => 'bar'} }
+    let(:options)   { {foo: 'bar'} }
     let(:base_url)  { "http://foo/" }
     let(:username)  { "username" }
     let(:password)  { "password" }
 
     before do
       subject.stub(
-        :options => options,
-        :base_url => base_url,
-        :username => username,
-        :password => password
+        options: options,
+        base_url: base_url,
+        username: username,
+        password: password
       )
     end
     specify :http_client_options do

--- a/spec/vend/http_client_spec.rb
+++ b/spec/vend/http_client_spec.rb
@@ -1,17 +1,16 @@
 require 'spec_helper'
 
 describe Vend::HttpClient do
-
   let(:base_url)  { "https://foo/bar/" }
   let(:username)  { "username" }
   let(:password)  { "password" }
-  let(:options)   {
+  let(:options)   do
     {base_url: base_url, username: username, password: password}
-  }
+  end
 
-  subject {
+  subject do
     described_class.new(options)
-  }
+  end
 
   it_behaves_like "it has a logger"
 
@@ -57,10 +56,9 @@ describe Vend::HttpClient do
   end
 
   describe "#verify_mode" do
-
     context "when verify_ssl? is true" do
       before do
-        subject.stub(:verify_ssl? => true)
+        subject.stub(verify_ssl?: true)
       end
       specify :verify_mode do
         expect(subject.verify_mode).to eq OpenSSL::SSL::VERIFY_PEER
@@ -69,94 +67,90 @@ describe Vend::HttpClient do
 
     context "when verify_ssl? is false" do
       before do
-        subject.stub(:verify_ssl? => false)
+        subject.stub(verify_ssl?: false)
       end
       specify :verify_mode do
         expect(subject.verify_mode).to eq OpenSSL::SSL::VERIFY_NONE
       end
     end
-
   end
 
   describe "#request" do
-
     context "when using invalid credentials" do
-
       let(:username)  { "invalid" }
 
       it "raises an error" do
-        stub_request(:get, "https://invalid:password@foo/bar/products").
-          to_return(status: 401)
+        stub_request(:get, "https://invalid:password@foo/bar/products")
+          .to_return(status: 401)
 
-        expect {
+        expect do
           subject.request('products')
-        }.to raise_error(Vend::Unauthorized)
+        end.to raise_error(Vend::Unauthorized)
       end
-
     end
 
     it "throws an error when an invalid request is made" do
-      stub_request(:get, "https://username:password@foo/bar/invalid").
-        to_return(status: 404, body: '{"foo":"bar"}', headers: {})
+      stub_request(:get, "https://username:password@foo/bar/invalid")
+        .to_return(status: 404, body: '{"foo":"bar"}', headers: {})
 
-      expect {
+      expect do
         subject.request('invalid')
-      }.to raise_error(Vend::HTTPError)
+      end.to raise_error(Vend::HTTPError)
     end
 
     it "returns parsed JSON" do
-      stub_request(:get, "https://username:password@foo/bar/bun").
-        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
+      stub_request(:get, "https://username:password@foo/bar/bun")
+        .to_return(status: 200, body: '{"foo":"bar"}', headers: {})
       expect(subject.request("bun")).to eq({"foo" => "bar"})
     end
 
     it "returns nil if the response was empty" do
-      stub_request(:get, "https://username:password@foo/bar/bun").
-        to_return(status: 200, body: '', headers: {})
+      stub_request(:get, "https://username:password@foo/bar/bun")
+        .to_return(status: 200, body: '', headers: {})
       expect(subject.request("bun")).to be_nil
     end
     it "allows us to specify HTTP method" do
-      stub_request(:post, "https://username:password@foo/bar/foo").
-        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
+      stub_request(:post, "https://username:password@foo/bar/foo")
+        .to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
       response = subject.request('foo', method: :post)
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "allows us to set a request body" do
-      stub_request(:post, "https://username:password@foo/bar/foo").
-        with(body: "{\"post\":\"data\"}").
-        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
+      stub_request(:post, "https://username:password@foo/bar/foo")
+        .with(body: "{\"post\":\"data\"}")
+        .to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
       response = subject.request('foo', method: :post, body: '{"post":"data"}')
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "allows us to specify url parameters" do
-      stub_request(:get, "https://username:password@foo/bar/foo?foo=bar&baz=baloo&flum%5B0%5D=blob&flum%5B1%5D=splat").
-        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
+      stub_request(:get, "https://username:password@foo/bar/foo?foo=bar&baz=baloo&flum%5B0%5D=blob&flum%5B1%5D=splat")
+        .to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
-      response = subject.request('foo', url_params: {foo: "bar", baz: "baloo", flum: ["blob","splat"]})
+      response = subject.request('foo', url_params: {foo: "bar", baz: "baloo", flum: ["blob", "splat"]})
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "follows redirects" do
-      stub_request(:get, "https://username:password@foo/bar/foo").
-        to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "http://username:password@foo/bar/floo"})
+      stub_request(:get, "https://username:password@foo/bar/foo")
+        .to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "http://username:password@foo/bar/floo"})
 
-      stub_request(:get, "http://username:password@foo/bar/floo").
-        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
+      stub_request(:get, "http://username:password@foo/bar/floo")
+        .to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
       response = subject.request('foo')
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "raises an exception when the redirection limit is exceeded" do
-      stub_request(:get, "https://username:password@foo/bar/foo").
-        to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "https://username:password@foo/bar/foo"})
-      expect {
+      stub_request(:get, "https://username:password@foo/bar/foo")
+        .to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "https://username:password@foo/bar/foo"})
+      expect do
         subject.request('foo')
-      }.to raise_exception(Vend::RedirectionLimitExceeded)
+      end.to raise_exception(Vend::RedirectionLimitExceeded)
     end
   end
 end

--- a/spec/vend/http_client_spec.rb
+++ b/spec/vend/http_client_spec.rb
@@ -6,7 +6,7 @@ describe Vend::HttpClient do
   let(:username)  { "username" }
   let(:password)  { "password" }
   let(:options)   {
-    {:base_url => base_url, :username => username, :password => password}
+    {base_url: base_url, username: username, password: password}
   }
 
   subject {
@@ -44,7 +44,7 @@ describe Vend::HttpClient do
     let(:port)        { 42 }
 
     before do
-      subject.stub(:verify_mode => verify_mode)
+      subject.stub(verify_mode: verify_mode)
       expect(http).to receive(:use_ssl=).with(true)
       expect(http).to receive(:verify_mode=).with(verify_mode)
       expect(http).to receive(:read_timeout=).with(240)
@@ -86,7 +86,7 @@ describe Vend::HttpClient do
 
       it "raises an error" do
         stub_request(:get, "https://invalid:password@foo/bar/products").
-          to_return(:status => 401)
+          to_return(status: 401)
 
         expect {
           subject.request('products')
@@ -97,7 +97,7 @@ describe Vend::HttpClient do
 
     it "throws an error when an invalid request is made" do
       stub_request(:get, "https://username:password@foo/bar/invalid").
-        to_return(:status => 404, :body => '{"foo":"bar"}', :headers => {})
+        to_return(status: 404, body: '{"foo":"bar"}', headers: {})
 
       expect {
         subject.request('invalid')
@@ -106,46 +106,46 @@ describe Vend::HttpClient do
 
     it "returns parsed JSON" do
       stub_request(:get, "https://username:password@foo/bar/bun").
-        to_return(:status => 200, :body => '{"foo":"bar"}', :headers => {})
+        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
       expect(subject.request("bun")).to eq({"foo" => "bar"})
     end
 
     it "returns nil if the response was empty" do
       stub_request(:get, "https://username:password@foo/bar/bun").
-        to_return(:status => 200, :body => '', :headers => {})
+        to_return(status: 200, body: '', headers: {})
       expect(subject.request("bun")).to be_nil
     end
     it "allows us to specify HTTP method" do
       stub_request(:post, "https://username:password@foo/bar/foo").
-        to_return(:status => 200, :body => '{"foo":"bar"}', :headers => {})
+        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
-      response = subject.request('foo', :method => :post)
+      response = subject.request('foo', method: :post)
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "allows us to set a request body" do
       stub_request(:post, "https://username:password@foo/bar/foo").
-        with(:body => "{\"post\":\"data\"}").
-        to_return(:status => 200, :body => '{"foo":"bar"}', :headers => {})
+        with(body: "{\"post\":\"data\"}").
+        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
-      response = subject.request('foo', :method => :post, :body => '{"post":"data"}')
+      response = subject.request('foo', method: :post, body: '{"post":"data"}')
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "allows us to specify url parameters" do
       stub_request(:get, "https://username:password@foo/bar/foo?foo=bar&baz=baloo&flum%5B0%5D=blob&flum%5B1%5D=splat").
-        to_return(:status => 200, :body => '{"foo":"bar"}', :headers => {})
+        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
-      response = subject.request('foo', :url_params => {:foo => "bar", :baz => "baloo", :flum => ["blob","splat"]})
+      response = subject.request('foo', url_params: {foo: "bar", baz: "baloo", flum: ["blob","splat"]})
       expect(response).to eq({"foo" => "bar"})
     end
 
     it "follows redirects" do
       stub_request(:get, "https://username:password@foo/bar/foo").
-        to_return(:status => 302, :body => '{"bar":"baz"}', :headers => {"Location" => "http://username:password@foo/bar/floo"})
+        to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "http://username:password@foo/bar/floo"})
 
       stub_request(:get, "http://username:password@foo/bar/floo").
-        to_return(:status => 200, :body => '{"foo":"bar"}', :headers => {})
+        to_return(status: 200, body: '{"foo":"bar"}', headers: {})
 
       response = subject.request('foo')
       expect(response).to eq({"foo" => "bar"})
@@ -153,7 +153,7 @@ describe Vend::HttpClient do
 
     it "raises an exception when the redirection limit is exceeded" do
       stub_request(:get, "https://username:password@foo/bar/foo").
-        to_return(:status => 302, :body => '{"bar":"baz"}', :headers => {"Location" => "https://username:password@foo/bar/foo"})
+        to_return(status: 302, body: '{"bar":"baz"}', headers: {"Location" => "https://username:password@foo/bar/foo"})
       expect {
         subject.request('foo')
       }.to raise_exception(Vend::RedirectionLimitExceeded)

--- a/spec/vend/oauth2/auth_code_spec.rb
+++ b/spec/vend/oauth2/auth_code_spec.rb
@@ -32,7 +32,7 @@ describe Vend::Oauth2::AuthCode do
 
     before do
       stub_request(:post, "https://store.vendhq.com/api/1.0/token").
-          to_return(:status => 200, :body => {token_type: token_type,
+          to_return(status: 200, body: {token_type: token_type,
 	                expires: 2435942384,
                   domain_prefix: store,
                   access_token: access_token,

--- a/spec/vend/oauth2/auth_code_spec.rb
+++ b/spec/vend/oauth2/auth_code_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Oauth2::AuthCode do
-
   subject { described_class.new('store', 'client_id', 'secret', 'redirect_uri') }
 
   describe "#initialize" do
@@ -23,21 +22,20 @@ describe Vend::Oauth2::AuthCode do
     end
   end
 
-
   describe "#token_from_code" do
-    let(:store) {"store"}
+    let(:store) { "store" }
     let(:token_type) { "Bearer" }
-    let(:access_token) { "Uy4eObSRn1RwzQbAitDMEkY6thdHsDJjwdGehpgr"}
-    let(:refresh_token) {"nbCoejmJp1XZgs7as6FeQQ5QZLlUfefzaBjrxvtV"}
+    let(:access_token) { "Uy4eObSRn1RwzQbAitDMEkY6thdHsDJjwdGehpgr" }
+    let(:refresh_token) { "nbCoejmJp1XZgs7as6FeQQ5QZLlUfefzaBjrxvtV" }
 
     before do
-      stub_request(:post, "https://store.vendhq.com/api/1.0/token").
-          to_return(status: 200, body: {token_type: token_type,
-	                expires: 2435942384,
-                  domain_prefix: store,
-                  access_token: access_token,
-                  refresh_token: refresh_token,
-                  expires_at: 2435942383}.to_json, :headers=>{ 'Content-Type' => 'application/json' })
+      stub_request(:post, "https://store.vendhq.com/api/1.0/token")
+          .to_return(status: 200, body: {token_type: token_type,
+                                         expires: 2435942384,
+                                         domain_prefix: store,
+                                         access_token: access_token,
+                                         refresh_token: refresh_token,
+                                         expires_at: 2435942383}.to_json, headers: { 'Content-Type' => 'application/json' })
     end
 
     it "return access token" do
@@ -47,5 +45,4 @@ describe Vend::Oauth2::AuthCode do
       expect(token.refresh_token).to eq(refresh_token)
     end
   end
-
 end

--- a/spec/vend/oauth2/client_spec.rb
+++ b/spec/vend/oauth2/client_spec.rb
@@ -25,23 +25,23 @@ describe Vend::Oauth2::Client do
   end
 
   describe "#http_client_options" do
-    let(:options)   { {:foo => 'bar'} }
+    let(:options)   { {foo: 'bar'} }
     let(:base_url)  { "http://foo/" }
     let(:auth_token)  { "auth_token" }
 
     before do
       subject.stub(
-        :options => options,
-        :base_url => base_url,
-        :auth_token => auth_token
+        options: options,
+        base_url: base_url,
+        auth_token: auth_token
       )
     end
 
     specify :http_client_options do
       expect(subject.http_client_options).to eq({
-        :foo => 'bar',
-        :base_url => base_url,
-        :auth_token => auth_token
+        foo: 'bar',
+        base_url: base_url,
+        auth_token: auth_token
       })
     end
   end

--- a/spec/vend/oauth2/client_spec.rb
+++ b/spec/vend/oauth2/client_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Oauth2::Client do
-
   subject { described_class.new('store', 'auth_token') }
 
   it_behaves_like "it has a logger"

--- a/spec/vend/pagination_info_spec.rb
+++ b/spec/vend/pagination_info_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::PaginationInfo do
-
   subject { described_class.new(response) }
 
   let(:response)  { double("response") }
@@ -11,7 +10,7 @@ describe Vend::PaginationInfo do
   end
 
   context "when response has pagination info" do
-    let(:response)  {
+    let(:response)  do
       {
         "pagination" => {
           "results"   => 7461,
@@ -20,7 +19,7 @@ describe Vend::PaginationInfo do
           "pages"     => 75
         }
       }
-    }
+    end
 
     specify :pages do
       expect(subject.pages).to eq 75
@@ -48,7 +47,6 @@ describe Vend::PaginationInfo do
           expect(subject).to be_last_page
         end
       end
-
     end
   end
 

--- a/spec/vend/pagination_info_spec.rb
+++ b/spec/vend/pagination_info_spec.rb
@@ -41,7 +41,7 @@ describe Vend::PaginationInfo do
 
       context "when page is equal to pages" do
         before do
-          subject.stub(:page => 42, :pages => 42)
+          subject.stub(page: 42, pages: 42)
         end
 
         specify :is_last_page do

--- a/spec/vend/resource/register_sale_product_spec.rb
+++ b/spec/vend/resource/register_sale_product_spec.rb
@@ -12,11 +12,11 @@ describe Vend::Resource::RegisterSaleProduct do
   describe "provides an attr reader for the attributes in attrs" do
     let(:attr1) { double("attr1") }
 
-    let(:attrs) {
+    let(:attrs) do
       {
         "attr1" => attr1
       }
-    }
+    end
 
     it "responds to attr1" do
       expect(subject.send(:attr1)).to eq attr1

--- a/spec/vend/resource/register_sale_spec.rb
+++ b/spec/vend/resource/register_sale_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Vend::Resource::RegisterSale do
-
   subject { described_class.new(nil, {}) }
 
   describe "#register_sale_products" do
@@ -9,12 +8,12 @@ describe Vend::Resource::RegisterSale do
     let(:raw_register_sale_product) { double("raw register sale prodcut") }
 
     before do
-      subject.stub(:attrs) {
+      subject.stub(:attrs) do
         { "register_sale_products" => [raw_register_sale_product] }
-      }
-      Vend::Resource::RegisterSaleProduct.stub(:new).with(raw_register_sale_product) {
+      end
+      Vend::Resource::RegisterSaleProduct.stub(:new).with(raw_register_sale_product) do
         register_sale_product
-      }
+      end
     end
 
     it "returns all the register sale products" do

--- a/spec/vend/resource_collection_spec.rb
+++ b/spec/vend/resource_collection_spec.rb
@@ -44,7 +44,7 @@ describe Vend::ResourceCollection do
         described_class.new(client, target_class, endpoint)
       }
 
-      before { target_class.stub(:default_collection_request_args => {:foo => :bar}) }
+      before { target_class.stub(default_collection_request_args: {foo: :bar}) }
 
       specify :request_args  do
         expect(subject.request_args).to eq({ foo: :bar })
@@ -98,7 +98,7 @@ describe Vend::ResourceCollection do
       let(:value)       { double("value") }
       let(:pagination)  { double("pagination", :paged? => value) }
       before do
-        subject.stub(:pagination => pagination)
+        subject.stub(pagination: pagination)
       end
 
       it "delegates to #pagination" do
@@ -119,7 +119,7 @@ describe Vend::ResourceCollection do
       let(:value)       { double("value") }
       let(:pagination)  { double("pagination", method => value) }
       before do
-        subject.stub(:pagination => pagination)
+        subject.stub(pagination: pagination)
       end
       it "delegates to #pagination" do
         expect(subject.send(method)).to eq value
@@ -136,7 +136,7 @@ describe Vend::ResourceCollection do
     context "when scope is not already present" do
       before do
         subject.stub(:has_scope?).with(:name) { false }
-        subject.stub(:scopes => scopes)
+        subject.stub(scopes: scopes)
         Vend::Scope.stub(:new).with(:name, value) { scope }
         expect(scopes).to receive(:<<).with(scope)
       end
@@ -248,7 +248,7 @@ describe Vend::ResourceCollection do
       let(:scope2) { "scope2" }
       let(:scopes) { [scope1, scope2] }
       before do
-        subject.stub(:scopes => scopes)
+        subject.stub(scopes: scopes)
       end
 
       specify :endpoint_with_scopes do
@@ -270,11 +270,11 @@ describe Vend::ResourceCollection do
     end
 
     context "when paged" do
-      let(:page_scope)  { double("page_scope", :value => 1) }
+      let(:page_scope)  { double("page_scope", value: 1) }
 
       before do
         subject.stub(:paged? => true)
-        subject.stub(:page => 1)
+        subject.stub(page: 1)
         expect(subject).to receive(:get_or_create_page_scope) { page_scope }
         expect(page_scope).to receive(:value=).with(2) { 2 }
       end
@@ -290,7 +290,7 @@ describe Vend::ResourceCollection do
     let(:page)        { 1 }
 
     before do
-      subject.stub(:page => page)
+      subject.stub(page: page)
       expect(subject).to receive(:get_scope).with(:page) { page_scope }
     end
 
@@ -317,12 +317,12 @@ describe Vend::ResourceCollection do
 
   describe "#get_scope" do
     let(:scope_name)  { :scope_name }
-    let(:scope)       { double("scope", :name => scope_name) }
+    let(:scope)       { double("scope", name: scope_name) }
 
     context "when scope is present" do
 
       before do
-        subject.stub(:scopes => [scope])
+        subject.stub(scopes: [scope])
       end
 
       specify do
@@ -332,7 +332,7 @@ describe Vend::ResourceCollection do
 
     context "when scope is not present" do
       before do
-        subject.stub(:scopes => [])
+        subject.stub(scopes: [])
       end
 
       specify do

--- a/spec/vend/resource_collection_spec.rb
+++ b/spec/vend/resource_collection_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Vend::ResourceCollection do
-
   let(:client)        { double("client") }
-  let(:target_class)  {
+  let(:target_class)  do
     double("target_class", default_collection_request_args: {})
-  }
+  end
   let(:endpoint)      { "endpoint" }
   let(:request_args)  { {} }
 
@@ -40,9 +39,9 @@ describe Vend::ResourceCollection do
     end
 
     context "when target class has default request args" do
-      subject {
+      subject do
         described_class.new(client, target_class, endpoint)
-      }
+      end
 
       before { target_class.stub(default_collection_request_args: {foo: :bar}) }
 
@@ -96,7 +95,7 @@ describe Vend::ResourceCollection do
   describe "#paged?" do
     context "when pagination is set" do
       let(:value)       { double("value") }
-      let(:pagination)  { double("pagination", :paged? => value) }
+      let(:pagination)  { double("pagination", paged?: value) }
       before do
         subject.stub(pagination: pagination)
       end
@@ -113,20 +112,18 @@ describe Vend::ResourceCollection do
     end
   end
 
-=begin
-  [:pages, :page].each do |method|
-    describe method do
-      let(:value)       { double("value") }
-      let(:pagination)  { double("pagination", method => value) }
-      before do
-        subject.stub(pagination: pagination)
-      end
-      it "delegates to #pagination" do
-        expect(subject.send(method)).to eq value
-      end
-    end
-  end
-=end
+  #   [:pages, :page].each do |method|
+  #     describe method do
+  #       let(:value)       { double("value") }
+  #       let(:pagination)  { double("pagination", method => value) }
+  #       before do
+  #         subject.stub(pagination: pagination)
+  #       end
+  #       it "delegates to #pagination" do
+  #         expect(subject.send(method)).to eq value
+  #       end
+  #     end
+  #   end
 
   describe "#scope" do
     let(:value)   { double("value") }
@@ -152,9 +149,9 @@ describe Vend::ResourceCollection do
       end
 
       it "raises and AlreadyScopedError" do
-        expect {
+        expect do
           subject.scope(:name, value)
-        }.to raise_exception(Vend::ResourceCollection::AlreadyScopedError)
+        end.to raise_exception(Vend::ResourceCollection::AlreadyScopedError)
       end
     end
   end
@@ -191,7 +188,6 @@ describe Vend::ResourceCollection do
   describe "#method_missing" do
     let(:value) { double("value") }
     context "when the method name is a valid scope name" do
-
       before do
         subject.stub(:accepts_scope?).with(:foo) { true }
       end
@@ -216,9 +212,9 @@ describe Vend::ResourceCollection do
       end
 
       it "raises method missing" do
-        expect {
+        expect do
           subject.foo(value)
-        }.to raise_exception(NoMethodError)
+        end.to raise_exception(NoMethodError)
       end
     end
   end
@@ -232,14 +228,14 @@ describe Vend::ResourceCollection do
     end
 
     specify :url do
-       expect(subject.url).to eq endpoint_with_scopes
+      expect(subject.url).to eq endpoint_with_scopes
     end
   end
 
   describe "#endpoint_with_scopes" do
     context "when there are no scopes" do
       specify :endpoint_with_scopes do
-         expect(subject.endpoint_with_scopes).to eq endpoint
+        expect(subject.endpoint_with_scopes).to eq endpoint
       end
     end
 
@@ -252,16 +248,15 @@ describe Vend::ResourceCollection do
       end
 
       specify :endpoint_with_scopes do
-         expect(subject.endpoint_with_scopes).to eq endpoint + scopes.join
+        expect(subject.endpoint_with_scopes).to eq endpoint + scopes.join
       end
     end
   end
 
   describe "#increment_page" do
     context "when not paged" do
-
       before do
-        subject.stub(:paged? => false)
+        subject.stub(paged?: false)
       end
 
       specify :increment_page do
@@ -273,14 +268,14 @@ describe Vend::ResourceCollection do
       let(:page_scope)  { double("page_scope", value: 1) }
 
       before do
-        subject.stub(:paged? => true)
+        subject.stub(paged?: true)
         subject.stub(page: 1)
         expect(subject).to receive(:get_or_create_page_scope) { page_scope }
         expect(page_scope).to receive(:value=).with(2) { 2 }
       end
 
       specify :increment_page do
-         expect(subject.increment_page).to eq 2
+        expect(subject.increment_page).to eq 2
       end
     end
   end
@@ -320,7 +315,6 @@ describe Vend::ResourceCollection do
     let(:scope)       { double("scope", name: scope_name) }
 
     context "when scope is present" do
-
       before do
         subject.stub(scopes: [scope])
       end
@@ -336,9 +330,9 @@ describe Vend::ResourceCollection do
       end
 
       specify do
-        expect{
+        expect do
           subject.get_scope(scope_name)
-        }.to raise_exception(Vend::ResourceCollection::ScopeNotFoundError)
+        end.to raise_exception(Vend::ResourceCollection::ScopeNotFoundError)
       end
     end
   end

--- a/spec/vend/scope_spec.rb
+++ b/spec/vend/scope_spec.rb
@@ -40,7 +40,7 @@ describe Vend::Scope do
     end
 
     context "when value is a timestamp" do
-      let(:value) { Time.new(2012,7,11,10,40,29) }
+      let(:value) { Time.new(2012, 7, 11, 10, 40, 29) }
       specify :escaped_value do
         expect(subject.escaped_value).to eq "2012-07-11+10%3A40%3A29"
       end

--- a/spec/vend/scope_spec.rb
+++ b/spec/vend/scope_spec.rb
@@ -18,7 +18,7 @@ describe Vend::Scope do
     let(:escaped_value) { "escaped_value" }
 
     before do
-      subject.stub(:escaped_value => escaped_value)
+      subject.stub(escaped_value: escaped_value)
     end
 
     specify :to_s do

--- a/vend.gemspec
+++ b/vend.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "vend/version"
 
 Gem::Specification.new do |s|
@@ -8,14 +8,14 @@ Gem::Specification.new do |s|
   s.authors     = ["Trineo Ltd"]
   s.email       = ["operations@trineo.co.nz"]
   s.homepage    = "http://trineo.co.nz"
-  s.summary     = %q{Vend REST API Gem}
-  s.description = %q{Ruby Gem to interface with the Vend REST API}
+  s.summary     = 'Vend REST API Gem'
+  s.description = 'Ruby Gem to interface with the Vend REST API'
 
   s.rubyforge_project = "vend"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "activesupport"


### PR DESCRIPTION
This started as a move to update Ruby hash syntax.

Adding Rubocop (and in future, managing it with houndCI) will allow future updates to be in a single Ruby style.

I set this as the Style we use at TradeGecko, but obviously, it's totally flexible.