### PR TITLE
Add supplier ressource

### DIFF
--- a/lib/vend.rb
+++ b/lib/vend.rb
@@ -19,6 +19,7 @@ require 'vend/resource/register_sale'
 require 'vend/resource/register_sale_product'
 require 'vend/resource/tax'
 require 'vend/resource/user'
+require 'vend/resource/supplier'
 
 require 'vend/http_client'
 require 'vend/client'

--- a/lib/vend/client.rb
+++ b/lib/vend/client.rb
@@ -59,6 +59,10 @@ module Vend #:nodoc:
       Vend::BaseFactory.new(self, Resource::User)
     end
 
+    def Supplier #:nodoc:
+      Vend::BaseFactory.new(self, Resource::Supplier)
+    end
+
     # Returns the base API url for the client.
     # E.g. for the store 'foo', it returns https://foo.vendhq.com/api/
     def base_url

--- a/lib/vend/resource/supplier.rb
+++ b/lib/vend/resource/supplier.rb
@@ -1,0 +1,23 @@
+module Vend
+  module Resource
+    class Supplier < Vend::Base
+      # Returns the endpoint name for a collection of this resource
+      def self.collection_name
+        endpoint_name
+      end
+
+      # Builds a collection of instances from a JSON response
+      def self.build_from_json(client, json)
+        json[collection_name.pluralize].map do |attrs|
+          self.build(client, attrs)
+        end
+      end
+
+      # Initializes a single object from a JSON response.
+      # Assumes the response is a JSON array with a single item.
+      def self.initialize_singular(client, json)
+        self.build(client, json[collection_name.pluralize].first)
+      end
+    end
+  end
+end

--- a/spec/integration/supplier_spec.rb
+++ b/spec/integration/supplier_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Vend::Resource::Supplier do
+  let(:expected_attributes) do
+    {
+      'id' => '6cb5c88c-3d5f-11e0-8697-4040f540b50a',
+      'name'   => 'Supplier Ben'
+    }
+  end
+
+  let(:expected_collection_length) { 1 }
+
+  it_behaves_like "a resource with a collection GET endpoint"
+end

--- a/spec/integration/supplier_spec.rb
+++ b/spec/integration/supplier_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Vend::Resource::Supplier do
   let(:expected_attributes) do
     {
-      'id' => '6cb5c88c-3d5f-11e0-8697-4040f540b50a',
-      'name'   => 'Supplier Ben'
+      'id' => '9fc84329-2d20-11e2-8057-080027706aa2',
+      'name'   => 'Brewer Supplies Ltd.'
     }
   end
 

--- a/spec/mock_responses/suppliers.json
+++ b/spec/mock_responses/suppliers.json
@@ -1,0 +1,36 @@
+{
+    "suppliers": [
+        {
+            "id": "9fc84329-2d20-11e2-8057-080027706aa2",
+            "retailer_id": "9a5521c3-2d20-11e2-8057-080027706aa2",
+            "name": "Brewer Supplies Ltd.",
+            "description": "We supply all things brewed\n",
+            "source": "USER",
+            "contact": {
+                "first_name": "First",
+                "last_name": "Last",
+                "company_name": "Co co",
+                "phone": "1-234-555-1234",
+                "mobile": null,
+                "fax": null,
+                "email": "no-reply+brewer-contact@vendhq.com",
+                "twitter": null,
+                "website": "www.brewer-supplies.com",
+                "physical_address1": null,
+                "physical_address2": null,
+                "physical_suburb": null,
+                "physical_city": null,
+                "physical_postcode": null,
+                "physical_state": null,
+                "physical_country_id": null,
+                "postal_address1": "123 Street St",
+                "postal_address2": null,
+                "postal_suburb": "Suburbia",
+                "postal_city": "New York",
+                "postal_postcode": "12345",
+                "postal_state": "New York",
+                "postal_country_id": "US"
+            }
+        }
+    ]
+}

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -27,12 +27,15 @@ shared_examples "a resource with a collection GET endpoint" do
     Vend::Client.new(store, username, password)
   end
 
-  it "gets the collection" do
-    url = "https://%s:%s@%s.vendhq.com/api/%s%s" % [
-      username, password, store, class_basename.to_s.underscore.pluralize,
-      append_to_url
-    ]
+  let(:endpoint) do
+    class_basename.to_s == 'Supplier' ? class_basename.to_s.underscore : class_basename.to_s.underscore.pluralize
+  end
 
+  it "gets the collection" do
+    url = "https://%s.vendhq.com/api/%s%s" % [
+      store, endpoint, append_to_url
+    ]
+    
     stub_request(:get, url).to_return(
       status: 200, body: get_mock_from_path(:get)
     )


### PR DESCRIPTION
https://developers.vendhq.com/documentation/api/0.x/suppliers.html

This endpoint differ from the others as its singular, but it's still returns something the records under a pluralized key:
```
{
  "suppliers": []
}
```